### PR TITLE
PER-223 added advance query support to rest adapter

### DIFF
--- a/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/README.md
+++ b/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/README.md
@@ -16,6 +16,7 @@ ___
 ## Example Qualification Mapping
 * userId=foo@bar.com
 * $filter=<object property name>="pizza"
+* $search="displayName:foo"
 ___
 ## Notes
 * To do a retrieve of a user the userId parameter must be passed in the qualification mapping.
@@ -23,3 +24,5 @@ ___
 * Only sorting supported by the Azure AD source system is allowed. i.e. no adapter side sorting.
 * Fields are automatically added to the Azure request as $select=...
     * Fields return are case sensitive.  If the return object has case then the field definition must match.
+* As per [Azure documentation](https://docs.microsoft.com/en-us/graph/aad-advanced-queries) if $search or $count is included as a search parameter the adapter will add **ConsistencyLevel: eventual** to the request headers.
+    * <path>/$count is not supported by the adapter

--- a/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/README.md
+++ b/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/README.md
@@ -25,4 +25,4 @@ ___
 * Fields are automatically added to the Azure request as $select=...
     * Fields return are case sensitive.  If the return object has case then the field definition must match.
 * As per [Azure documentation](https://docs.microsoft.com/en-us/graph/aad-advanced-queries) if $search or $count is included as a search parameter the adapter will add **ConsistencyLevel: eventual** to the request headers.
-    * <path>/$count is not supported by the adapter
+    * $count in the URI path is not supported

--- a/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/pom.xml
+++ b/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kineticdata.bridges.adapter</groupId>
     <artifactId>kinetic-bridgehub-adapter-azure-rest</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
     
     <name>kinetic-bridgehub-adapter-azure-rest</name>
@@ -87,7 +87,6 @@
             <type>jar</type>
             <scope>test</scope>
         </dependency>
-        
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/src/test/java/com/kineticdata/bridgehub/adapter/azure/rest/AzureRestApiHelperTest.java
+++ b/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/src/test/java/com/kineticdata/bridgehub/adapter/azure/rest/AzureRestApiHelperTest.java
@@ -1,0 +1,57 @@
+package com.kineticdata.bridgehub.adapter.azure.rest;
+
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class AzureRestApiHelperTest {
+    @Test
+    public void test_includes_search() {
+        HttpGet get = new HttpGet("https://graph.microsoft.com/v1.0/users?" +
+            "%24top=999&%24select=displayName%2Csurname&%24search=%22foo:bar%22");
+        
+        AzureRestApiHelper helper = new AzureRestApiHelper("", "", "", "");
+        
+        assertTrue(helper.isAdvancedQuery(get));
+    }
+    
+    @Test
+    public void test_includes_no_search() {
+        HttpGet get = new HttpGet("https://graph.microsoft.com/v1.0/users?" +
+            "%24top=999&%24select=displayName%2Csurname&%24");
+        
+        AzureRestApiHelper helper = new AzureRestApiHelper("", "", "", "");
+        
+        assertFalse(helper.isAdvancedQuery(get));
+    }
+    
+    @Test
+    public void test_includes_count_param() {
+        HttpGet get = new HttpGet("https://graph.microsoft.com/v1.0/users?" +
+            "%24top=999&%24select=displayName%2Csurname&%24count=true");
+        
+        AzureRestApiHelper helper = new AzureRestApiHelper("", "", "", "");
+        
+        assertTrue(helper.isAdvancedQuery(get));
+    }
+    
+    @Test
+    public void test_includes_count() {
+        HttpGet get = new HttpGet("https://graph.microsoft.com/v1.0/%24count");
+        
+        AzureRestApiHelper helper = new AzureRestApiHelper("", "", "", "");
+        
+        assertTrue(helper.isAdvancedQuery(get));
+    }
+    
+    @Test
+    public void test_includes_no_count() {
+        HttpGet get = new HttpGet("https://graph.microsoft.com/v1.0/users?" +
+            "%24top=999&%24select=displayName%2Csurname&%24");
+        
+        AzureRestApiHelper helper = new AzureRestApiHelper("", "", "", "");
+        
+        assertFalse(helper.isAdvancedQuery(get));
+    }
+}

--- a/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/src/test/java/com/kineticdata/bridgehub/adapter/azure/rest/AzureRestTest.java
+++ b/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/src/test/java/com/kineticdata/bridgehub/adapter/azure/rest/AzureRestTest.java
@@ -135,6 +135,37 @@ public class AzureRestTest extends BridgeAdapterTestBase{
     }
     
     @Test
+    public void test_search_query() throws Exception{
+        BridgeError error = null;
+        
+        // Create the Bridge Request
+        List<String> fields = new ArrayList<>();
+        fields.add("displayName");
+        fields.add("surname");
+        fields.add("userPrincipalName");
+        
+        BridgeRequest request = new BridgeRequest();
+        request.setStructure("Users");
+        request.setFields(fields);
+        request.setQuery("$search=\"displayName:<%=parameter[\"Display Name\"]%>\"");
+        
+        request.setParameters(new HashMap<String, String>() {{ 
+            put("Display Name", "Kim Abner");
+        }});
+        
+        
+        RecordList records = null;
+        try {
+            records = getAdapter().search(request);
+        } catch (BridgeError e) {
+            error = e;
+        }
+        
+        assertNull(error);
+        assertTrue(records.getRecords().size() > 0);
+    }
+    
+    @Test
     public void test_search_sort() throws Exception{
         BridgeError error = null;
         

--- a/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/src/test/resources/bridge-config.yml
+++ b/bridge-adapters/kinetic-bridgehub-adapter-azure-rest/src/test/resources/bridge-config.yml
@@ -18,7 +18,7 @@ Test Request Configuration:
     Structure: "Users"
     Fields: "displayName,surname"
     Empty Value Query: "" 
-    Single Value Query: "userId=-foo.bar"
+    Single Value Query: "$search=\"displayName:bar\""
     Multiple Value Query: ""
 
 # Configuration of the various metadata options

--- a/changelog.md
+++ b/changelog.md
@@ -16,4 +16,4 @@ Azure \[handlers\] (2021-05-18)
 
 Azure \[bridge-adapters\] (2020-02-07)
   \[kinetic-bridgehub-adapter-azure-rest\] v1.0.4
-    * Added support for $search and $count advanced query
+    * Added support for $search and $count advanced query parameters

--- a/changelog.md
+++ b/changelog.md
@@ -13,3 +13,7 @@ Azure \[handlers\] (2021-05-18)
     * Initial commit.
   \[azure_cosmos_document_crud] v1
     * Updated readme.
+
+Azure \[bridge-adapters\] (2020-02-07)
+  \[kinetic-bridgehub-adapter-azure-rest\] v1.0.4
+    * Added support for $search and $count advanced query


### PR DESCRIPTION
In order to support $select, $count and other advance query features exposed
by Azure a header needs to be provided.  We are adding the header conditionally
based on the query parameters in the qualification model.  Better error
message was included.